### PR TITLE
Botonones de NavBar. Evitar selección

### DIFF
--- a/src/components/Navbar/Buttons/AboutNav.jsx
+++ b/src/components/Navbar/Buttons/AboutNav.jsx
@@ -11,7 +11,7 @@ const AboutNav = () => {
 
   return (
     <div className="relative">
-      <div className="flex flex-row items-center gap-3">
+      <div className="flex flex-row items-center gap-3 select-none">
         <div
           className="
             p-4

--- a/src/components/Navbar/Buttons/LoginNav.tsx
+++ b/src/components/Navbar/Buttons/LoginNav.tsx
@@ -14,7 +14,7 @@ function LoginNav () {
 
   return (
     <div className="relative">
-      <div className="flex flex-row items-center gap-3">
+      <div className="flex flex-row items-center gap-3 select-none">
         <div
             className="
             p-4

--- a/src/components/Navbar/Buttons/MostValueNav.jsx
+++ b/src/components/Navbar/Buttons/MostValueNav.jsx
@@ -4,7 +4,7 @@ const MostValuedNav = () => {
 
   return (
     <div className="relative">
-      <div className="flex flex-row items-center gap-3">
+      <div className="flex flex-row items-center gap-3 select-none">
         <div
             className="
             p-4

--- a/src/components/Navbar/Buttons/NewProductsNav.jsx
+++ b/src/components/Navbar/Buttons/NewProductsNav.jsx
@@ -4,7 +4,7 @@ const NewProductsNav = () => {
   
     return (
       <div className="relative">
-        <div className="flex flex-row items-center gap-3">
+        <div className="flex flex-row items-center gap-3 select-none">
           <div
              className="
               p-4

--- a/src/components/Navbar/Buttons/RecommendationsNav.jsx
+++ b/src/components/Navbar/Buttons/RecommendationsNav.jsx
@@ -13,7 +13,7 @@ const RecomendationsNav = () => {
   };
   return (
     <div className="relative">
-      <div className="flex flex-row items-center gap-3">
+      <div className="flex flex-row items-center gap-3 select-none">
         <div
             className="
             p-4

--- a/src/components/Navbar/Buttons/RegisterNav.jsx
+++ b/src/components/Navbar/Buttons/RegisterNav.jsx
@@ -14,7 +14,7 @@ function RegisterNav () {
 
   return (
     <div className="relative">
-      <div className="flex flex-row items-center gap-3">
+      <div className="flex flex-row items-center gap-3 select-none">
         <div
             className="
             p-4

--- a/src/components/Navbar/Buttons/ShopNowNav.jsx
+++ b/src/components/Navbar/Buttons/ShopNowNav.jsx
@@ -11,7 +11,7 @@ function ShopNow () {
 
   return (
     <div className="relative">
-      <div className="flex flex-row items-center gap-3">
+      <div className="flex flex-row items-center gap-3 select-none">
         <div
             className="
             p-4

--- a/src/components/Navbar/Buttons/ShoppingCart.jsx
+++ b/src/components/Navbar/Buttons/ShoppingCart.jsx
@@ -10,7 +10,7 @@ const ShoppingCart = () => {
 
   return (
     <div className="relative">
-      <div className="flex flex-row items-center gap-3">
+      <div className="flex flex-row items-center gap-3 select-none">
         <div
           onClick={addToCart}
           className="

--- a/src/components/Navbar/Buttons/TopWeekNav.jsx
+++ b/src/components/Navbar/Buttons/TopWeekNav.jsx
@@ -4,7 +4,7 @@ const TopWeekNav = () => {
 
   return (
     <div className="relative">
-      <div className="flex flex-row items-center gap-3">
+      <div className="flex flex-row items-center gap-3 select-none">
         <div
             className="
             p-4

--- a/src/views/About/About.module.css
+++ b/src/views/About/About.module.css
@@ -41,6 +41,7 @@
     z-index: 10;
     transition: .2s;
     font-size: .9em;
+    user-select: none;
 }
 
 .img_content:hover > .img > .info{


### PR DESCRIPTION
genere una linea de codigo para que no se pueda seleccionar las palabras dentro de los botones  de la NavBar